### PR TITLE
Removed "highload" as it is un-needed

### DIFF
--- a/scaler.sh
+++ b/scaler.sh
@@ -39,8 +39,8 @@ function main {
   midfreq=${freqlist[$((${#freqlist[*]}/2))]}
 
   # Set load steps to trigger frequencies scaling, this user overidable
-  lowload=${lowload:=050}
-  midload=${midload:=065}
+  lowload=${lowload:=010}
+  midload=${midload:=020}
 
   for i in $(seq 0 ${cpucorecount})
     do

--- a/scaler.sh
+++ b/scaler.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+scriptname=`basename "$0"`
+if pidof -x $scriptname >/dev/null; then
+    echo "Process already running. Quitting now"
+    exit 0;
+fi
 
 # Get cpu cores count minus 1, to allow maping from 0
 cpucorecount=$(cat /proc/cpuinfo | grep cores | sort -u | awk '{ print $4 - 1 }')

--- a/scaler.sh
+++ b/scaler.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-scriptname=`basename "$0"`
-if pidof -x $scriptname >/dev/null; then
-    echo "Process already running. Quitting now"
-    exit 0;
-fi
 
 # Get cpu cores count minus 1, to allow maping from 0
 cpucorecount=$(cat /proc/cpuinfo | grep cores | sort -u | awk '{ print $4 - 1 }')

--- a/scaler.sh
+++ b/scaler.sh
@@ -41,7 +41,6 @@ function main {
   # Set load steps to trigger frequencies scaling, this user overidable
   lowload=${lowload:=050}
   midload=${midload:=065}
-  highload=${highload:=085}
 
   for i in $(seq 0 ${cpucorecount})
     do
@@ -49,7 +48,7 @@ function main {
         echo $minfreq > /sys/devices/system/cpu/cpu${i}/cpufreq/scaling_setspeed
       elif [ "$loadavg" -ge $((10#$lowload)) ] && [ "$loadavg" -le $((10#$midload)) ]; then
         echo $midfreq > /sys/devices/system/cpu/cpu${i}/cpufreq/scaling_setspeed
-      elif [ "$loadavg" -ge $((10#$highload)) ]; then
+      elif [ "$loadavg" -ge $((10#$midload)) ]; then
         echo $maxfreq > /sys/devices/system/cpu/cpu${i}/cpufreq/scaling_setspeed
       fi
   done


### PR DESCRIPTION
The script is designed to set 3 CPU frequencies - min, medium & max. Before this change, it would check if the CPU was above "highload" before setting it to max speed. This would mean that the script would be NOOP, between "midload" & "highload" values.
Changed that, so it goes to max, above midload value. 

Other scaling behaviour is unchanged.